### PR TITLE
14241 - remover textEditSecretariaJT

### DIFF
--- a/primeirograu/jesp/Elaboração de documentos.xml
+++ b/primeirograu/jesp/Elaboração de documentos.xml
@@ -21,7 +21,7 @@
     <task-node end-tasks="true" name="Elaborar documento">
         <task name="Elaborar documento" swimlane="Secretaria">
             <controller>
-                <variable name="minutaEmElaboracao" mapped-name="textEditSecretariaJT:minutaEmElaboracao" access="read,write"/>
+                <variable name="minutaEmElaboracao" mapped-name="textEditCombo:minutaEmElaboracao" access="read,write"/>
             </controller>
         </task>
         <transition to="Nó de Desvio - Elaboração de documentos" name="Nó de Desvio - Elaboração de documentos">

--- a/primeirograu/jesp/Fluxo básico de conhecimento.xml
+++ b/primeirograu/jesp/Fluxo básico de conhecimento.xml
@@ -121,7 +121,7 @@
     <task-node end-tasks="true" name="Expedir alvará judicial">
         <task name="Expedir alvará judicial" swimlane="Secretaria">
             <controller>
-                <variable name="minutaEmElaboracao" mapped-name="textEditSecretariaJT:minutaEmElaboracao" access="read,write"/>
+                <variable name="minutaEmElaboracao" mapped-name="textEditCombo:minutaEmElaboracao" access="read,write"/>
             </controller>
         </task>
         <transition to="Nó de Desvio - Fluxo básico de conhecimento" name="Nó de Desvio - Fluxo básico de conhecimento">


### PR DESCRIPTION
	Informação não mais utilizada na versão 2.x.x.
	O fluxo também foi substituido para uma para um mais novo.