### PR TITLE
Apagar os movimentos em fluxo de Ato Ordinatório em SG

### DIFF
--- a/segundograu/sg/(SG) Expedição de ato ordinatório de gabinete.xml
+++ b/segundograu/sg/(SG) Expedição de ato ordinatório de gabinete.xml
@@ -74,6 +74,8 @@ Assessoria Segundo Grau  Assessor Geral]]></description>
         <event type="task-create">
             <action expression="#{tramitacaoProcessualService.gravaVariavelTarefa('tiposDisponiveisIds','67')}"/>
             <action expression="#{tramitacaoProcessualService.gravaVariavelTarefa('pje:fluxo:transicao:dispensaRequeridos', 'Cancelar elaboração de ato ordinatório,Documento já assinado!')}"/>
+            <action expression="#{tramitacaoProcessualService.apagaVariavel('MovimentosLancadosTemporariamente')}"/>
+            <action expression="#{tramitacaoProcessualService.apagaVariavel('AgrupamentosLancadosTemporariamente')}"/>
         </event>
         <event type="node-enter">
             <action expression="#{ not empty tramitacaoProcessualService.recuperaVariavel('minutaEmElaboracao') ? processoDocumentoHome.setInstance(processoDocumentoManager.findById(tramitacaoProcessualService.recuperaVariavel('minutaEmElaboracao'))) : '' }"/>

--- a/segundograu/sg/(SG) Expedição de ato ordinatório do gabinete à PGJ.xml
+++ b/segundograu/sg/(SG) Expedição de ato ordinatório do gabinete à PGJ.xml
@@ -74,6 +74,8 @@ Assessoria Segundo Grau  Assessor Geral]]></description>
         <event type="task-create">
             <action expression="#{tramitacaoProcessualService.gravaVariavelTarefa('tiposDisponiveisIds','67')}"/>
             <action expression="#{tramitacaoProcessualService.gravaVariavelTarefa('pje:fluxo:transicao:dispensaRequeridos', 'Cancelar elaboração de ato ordinatório,Documento já assinado!')}"/>
+            <action expression="#{tramitacaoProcessualService.apagaVariavel('MovimentosLancadosTemporariamente')}"/>
+            <action expression="#{tramitacaoProcessualService.apagaVariavel('AgrupamentosLancadosTemporariamente')}"/>
         </event>
         <event type="node-enter">
             <action expression="#{ not empty tramitacaoProcessualService.recuperaVariavel('minutaEmElaboracao') ? processoDocumentoHome.setInstance(processoDocumentoManager.findById(tramitacaoProcessualService.recuperaVariavel('minutaEmElaboracao'))) : '' }"/>


### PR DESCRIPTION
Processo chegando na tarefa de Ato Ordinatório com movimento preenchido. A alteração irá retirar esses movimentos quando o processo chegar na tarefa.