### PR TITLE
Excluir variável "minuta_semefeito" ao sair da tarefa

### DIFF
--- a/primeirograu/vciv/(VCiv) Preparar Ato Judicial.xml
+++ b/primeirograu/vciv/(VCiv) Preparar Ato Judicial.xml
@@ -294,6 +294,8 @@
         <transition to="(VCiv) É sentença?" name="(VCiv) É sentença?"/>
         <event type="node-enter">
             <action expression="#{tramitacaoProcessualService.apagaVariavel('pje:paj:certidaosemefeito')}"/>
+            <action expression="#{tramitacaoProcessualService.apagaVariavel('minuta_semefeito')}"/>
+            <action expression="#{tramitacaoProcessualService.apagaVariavel('textEditSignature:minuta_semefeito')}"/>
         </event>
     </fork>
     <join name="(VCiv) Junção de atos judiciais">


### PR DESCRIPTION
excluir variável ao sair da tarefa de emitir certidão sem efeito, para evitar que o documento seja excluído após assinar