### PR TITLE
Permitir que atos ordinatórios sejam assinados em lote

### DIFF
--- a/segundograu/sg/(SG) Expedição de ato ordinatório de gabinete.xml
+++ b/segundograu/sg/(SG) Expedição de ato ordinatório de gabinete.xml
@@ -85,7 +85,7 @@ Assessoria Segundo Grau  Assessor Geral]]></description>
         </event>
     </task-node>
     <task-node end-tasks="true" name="(SG) Ato ordinatório do gabinete - ASSINAR">
-        <task name="(SG) Ato ordinatório do gabinete - ASSINAR" swimlane="Assessoria" priority="3">
+        <task name="(SG) Ato ordinatório do gabinete - ASSINAR" swimlane="Assessoria" priority="4">
             <controller>
                 <variable name="Processo_Fluxo_revisarMinuta" mapped-name="frame:Processo_Fluxo_revisarMinuta" access="read,write"/>
                 <variable name="movimentacaoLote" mapped-name="movimentarLote:movimentacaoLote" access="read,write"/>

--- a/segundograu/sg/(SG) Expedição de ato ordinatório do gabinete à PGJ.xml
+++ b/segundograu/sg/(SG) Expedição de ato ordinatório do gabinete à PGJ.xml
@@ -85,7 +85,7 @@ Assessoria Segundo Grau  Assessor Geral]]></description>
         </event>
     </task-node>
     <task-node end-tasks="true" name="(SG) Ato ordinatório do gabinete à PGJ - ASSINAR">
-        <task name="(SG) Ato ordinatório do gabinete à PGJ - ASSINAR" swimlane="Assessoria">
+        <task name="(SG) Ato ordinatório do gabinete à PGJ - ASSINAR" swimlane="Assessoria" priority="4">
             <controller>
                 <variable name="Processo_Fluxo_revisarMinuta" mapped-name="frame:Processo_Fluxo_revisarMinuta" access="read,write"/>
                 <variable name="movimentacaoLote" mapped-name="movimentarLote:movimentacaoLote" access="read,write"/>


### PR DESCRIPTION
Caso sejam criadas novas entradas na tabela jbpm_task, o valor da coluna priority deve estar como 4 para permitir que a tarefa possa ser assinada em lote.