### PR TITLE
Removendo teste condicional para permitir a visualização da transição de saída "15 - Enviar concluso para despacho inicial" pelos juízados especiais.

### DIFF
--- a/primeirograu/vciv/(VCiv) Fluxo básico de conhecimento.xml
+++ b/primeirograu/vciv/(VCiv) Fluxo básico de conhecimento.xml
@@ -193,9 +193,7 @@ Aguardar Perícia / Laudo Técnico / Outros...]]></description>
             <condition expression="#{(parametroUtil.getParametro('pje:tjrn:fluxo:ef:ojs:ids').contains('_'.concat(tramitacaoProcessualService.recuperaProcesso().orgaoJulgador.idOrgaoJulgador).concat('_'))) &amp;&amp; processoTrfHome.possuiClasse(23)}"/>
         </transition>
         <transition to="(VCiv) Conclusão para decisão de urgência inicial" name="07 - Enviar concluso para decisão de urgência inicial"/>
-        <transition to="(VCiv) Conclusão para despacho inicial" name="15 - Enviar concluso para despacho inicial">
-            <condition expression="#{!(parametroUtil.getParametro('pje:tjrn:OJsJuizados').contains('_'.concat(tramitacaoProcessualService.recuperaProcesso().orgaoJulgador.idOrgaoJulgador).concat('_')))}"/>
-        </transition>
+        <transition to="(VCiv) Conclusão para despacho inicial" name="15 - Enviar concluso para despacho inicial"/>
         <transition to="(VCiv) Dar cumprimento a ato judicial de penhora online" name="20 - Dar cumprimento a ato judicial de penhora online"/>
         <transition to="(VCiv) Citar com um clique" name="21 - Citar com um clique"/>
         <event type="node-enter">


### PR DESCRIPTION
No redmine 23064 foi solicitado a inclusão da opção "Enviar concluso para despacho inicial" na tarefa Análise da secretaria dos juizados especiais. Após análise, foi identificado que havia o teste condicoinal 
`#{!(parametroUtil.getParametro('pje:tjrn:OJsJuizados').contains('_'.concat(tramitacaoProcessualService.recuperaProcesso().orgaoJulgador.idOrgaoJulgador).concat('_')))}` 

responsável por verificar e ocultar a transição de saída para os juizados especiais declarados na variável "pje:tjrn:OJsJuizados". Dessa forma, foi efetuada a removação do referido teste, de modo a permitir a visualização da transição de saída "15 - Enviar concluso para despacho inicial" pelos juízados especiais.